### PR TITLE
Make launching of browser optional during startup

### DIFF
--- a/R/route.r
+++ b/R/route.r
@@ -44,9 +44,10 @@ check_for_package <- function(package) {
 #' Start helpr.
 #' 
 #' @export
-#' @param installed use TRUE if the package is installed on from CRAN
+#' @param launch_browser should this function launch a browser for immediate
+#'        viewing of help pages?
 #' @author Hadley Wickham and Barret Schloerke \email{schloerke@@gmail.com}
-helpr <- function() {
+helpr <- function(launch_browser = TRUE) {
   path <- helpr_path()
 
   router <- Router$clone()
@@ -267,7 +268,7 @@ helpr <- function() {
   render_path <- function(path, query, ...) router$route(path, query)
   assignInNamespace("httpd", render_path, "tools")
   if (tools:::httpdPort == 0L) {
-    help.start()
+    if(launch_browser) help.start()
     options("help_type" = "html")
     if(!solr_exists()) solr_FAIL()
     

--- a/man/helpr.Rd
+++ b/man/helpr.Rd
@@ -1,6 +1,8 @@
 \name{helpr}
 \alias{helpr}
 \title{Start helpr.}
+\usage{helpr(launch_browser=TRUE)}
 \description{Start helpr.}
 \author{Hadley Wickham and Barret Schloerke \email{schloerke@gmail.com}}
-\arguments{\item{installed}{use TRUE if the package is installed on from CRAN}}
+\arguments{\item{launch_browser}{should this function launch a browser for immediate
+viewing of help pages?}}


### PR DESCRIPTION
Invoking the `helpr` function causes a call to `help.start` which yanks the user out of the R environment and drops them into a browser.  This behavior is undesirable if a user wishes to make helpr their default help system by adding a call to `helpr` in their R startup procedure as it causes the user to be dumped into a web browser _every_ time they launch R and forces them to navigate back to the R console.

This change adds an optional argument, `launch_browser`, to the `helpr` function which will suppress the call to `help.start` if set to `TRUE`. This allows users to call `helpr(lanch_browser=FALSE)` in a startup script and delay the launching of a browser will be delayed until the first time the user accesses a help page using `?` or `help`.
