### PR TITLE
Don't ignore the help_type parameter

### DIFF
--- a/R/route.r
+++ b/R/route.r
@@ -364,6 +364,12 @@ print.help_files_with_topic <- function (x, ...)
     browser <- getOption("browser")
     topic <- attr(x, "topic")
     type <- attr(x, "type")
+
+    if (type != 'html') {
+      # HTML help was not requested. Punt call back to R's default help system
+      return(invisible(utils:::print.help_files_with_topic(x)))
+    }
+
     paths <- as.character(x)
     if (!length(paths)) {
         writeLines(c(gettextf("No documentation for '%s' in specified packages and libraries:", 


### PR DESCRIPTION
When helpr is loaded, it provides a new default method for:

```
print.help_files_with_topic
```

Currently, this method always serves HTML help, even if a user provides a
different argument to the help function such as `help(..., help_type =
'text')`.

This patch fixes this behavior by calling back to
`utils:::print.help_files_with_topic` if the requested help type was something
other than 'html'.
