### PR TITLE
Added support for `\references{}'` to topic documentation

### DIFF
--- a/R/functions.r
+++ b/R/functions.r
@@ -165,6 +165,7 @@ helpr_function <- function(package, func) {
     aliases = aliases,
     aliases_str = pluralize("Topic (Source)", aliases, plural="Topics (Source)"),
     desc = gsub("$\n+|\n+^", "", reconstruct(pkg_topic(package, topic)$description, package)),
+    references = gsub("$\n+|\n+^", "", reconstruct(pkg_topic(package, topic)$references, package)),
     src = src,
     src_functions = src_functions,
     src_functions_str = src_functions_str,

--- a/R/parse-rd.r
+++ b/R/parse-rd.r
@@ -213,7 +213,7 @@ tag_link <- function(fun, pkg = NULL, topic_page = fun) {
 #' @author Hadley Wickham
 #' @keywords internal
 is_section <- function(tag) {
-  tag %in% c("\\details", "\\description", "\\value", "\\author", "\\seealso")
+  tag %in% c("\\details", "\\description", "\\value", "\\author", "\\seealso", "\\references")
 }
 
 #' All tags that can be parsed in a simple way.

--- a/R/topic.r
+++ b/R/topic.r
@@ -91,6 +91,7 @@ parse_help <- function(rd, package) {
   # single string.
   out$title <- reconstruct(untag(rd$title), package)
   out$desc <- gsub("$\n+|\n+^", "", reconstruct(rd$description, package))
+  out$references <- gsub("$\n+|\n+^", "", reconstruct(rd$references, package))
   out$details <- reconstruct(rd$details, package)
   out$value <- reconstruct(rd$value, package)
   reconstructed_examples <- reconstruct(untag(rd$examples), package)

--- a/inst/views/topic.html
+++ b/inst/views/topic.html
@@ -78,6 +78,10 @@
   <% if(has_text(source)){ -%>
     <h2>Source</h2><%= source %>
   <% }%>
+  
+  <% if(has_text(references)){ -%>
+    <h2>References</h2><%= references %>
+  <% }%>
 
   
 </div>


### PR DESCRIPTION
As an exercise to get to know the `helpr` package, I added support for `\references{}` to topic documentation.  I essentially just copied the code used to create the `\description{}' section. Here is the result, if needed.
